### PR TITLE
Highlight default decimal option on load

### DIFF
--- a/ShaunFeldman.html
+++ b/ShaunFeldman.html
@@ -210,6 +210,8 @@
       const API_URL = 'https://api.frankfurter.app';
       // Set default decimals to 2
       let currentDecimals = "2";
+      // Highlight default decimals button on load
+      $('.decimal-btn[data-decimals="2"]').addClass('active');
       
       // Populate currency dropdowns using the API
       $.getJSON(API_URL + '/currencies', function(data) {


### PR DESCRIPTION
## Summary
- ensure the default `2` decimals button is highlighted when the page loads

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8abedca40832c9bea5db038b7b550