### PR TITLE
Add Jest test suite for convertCurrency

### DIFF
--- a/ShaunFeldman.html
+++ b/ShaunFeldman.html
@@ -205,11 +205,10 @@
   </div>
   <!-- jQuery library (CDN) -->
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="convertCurrency.js"></script>
   <script>
     $(function() {
       const API_URL = 'https://api.frankfurter.app';
-      // Set default decimals to 2
-      let currentDecimals = "2";
       
       // Populate currency dropdowns using the API
       $.getJSON(API_URL + '/currencies', function(data) {
@@ -246,7 +245,7 @@
       
       // Decimal buttons event: update currentDecimals and active style
       $('.decimal-btn').on('click', function() {
-        currentDecimals = $(this).data('decimals').toString();
+        setCurrentDecimals($(this).data('decimals').toString());
         $('.decimal-btn').removeClass('active');
         $(this).addClass('active');
         convertCurrency();
@@ -259,47 +258,6 @@
         $('#amount').attr('placeholder', `Enter amount in ${fromCurrency}`);
       }
       
-      // Conversion function: fetches rate and displays result instantly
-      // The input amount is shown as entered, while the converted output is formatted.
-      function convertCurrency() {
-        const rawInput = $('#amount').val().trim(); // Use raw input value for display
-        const from = $('#from-currency').val();
-        const to = $('#to-currency').val();
-        
-        if (rawInput === '') {
-          $('#result').text('Enter an amount to convert.');
-          return;
-        }
-        
-        const amount = parseFloat(rawInput);
-        if (isNaN(amount)) {
-          $('#result').text('Please enter a valid number.');
-          return;
-        }
-        
-        // If currencies are the same, just echo the input value for both
-        if (from === to) {
-          $('#result').text(`${rawInput} ${from} = ${rawInput} ${to}`);
-          return;
-        }
-        
-        // Fetch the conversion rate from the API and calculate the result
-        $.getJSON(`${API_URL}/latest?base=${from}&symbols=${to}`, function(data) {
-          if (data && data.rates && data.rates[to]) {
-            const rate = data.rates[to];
-            const convertedValue = amount * rate;
-            // Only the converted value is formatted according to the selected decimal option.
-            const formattedConverted = (currentDecimals === "ALL") 
-              ? convertedValue.toString() 
-              : convertedValue.toFixed(currentDecimals);
-            $('#result').text(`${rawInput} ${from} = ${formattedConverted} ${to}`);
-          } else {
-            $('#result').text('Conversion rate not available.');
-          }
-        }).fail(function() {
-          $('#result').text('Error fetching conversion rate.');
-        });
-      }
     });
   </script>
 </body>

--- a/convertCurrency.js
+++ b/convertCurrency.js
@@ -1,0 +1,52 @@
+const API_URL = 'https://api.frankfurter.app';
+let currentDecimals = "2";
+
+function convertCurrency() {
+  const rawInput = $('#amount').val().trim();
+  const from = $('#from-currency').val();
+  const to = $('#to-currency').val();
+
+  if (rawInput === '') {
+    $('#result').text('Enter an amount to convert.');
+    return;
+  }
+
+  const amount = parseFloat(rawInput);
+  if (isNaN(amount)) {
+    $('#result').text('Please enter a valid number.');
+    return;
+  }
+
+  if (from === to) {
+    $('#result').text(`${rawInput} ${from} = ${rawInput} ${to}`);
+    return;
+  }
+
+  $.getJSON(`${API_URL}/latest?base=${from}&symbols=${to}`, function(data) {
+    if (data && data.rates && data.rates[to]) {
+      const rate = data.rates[to];
+      const convertedValue = amount * rate;
+      const formattedConverted = (currentDecimals === "ALL")
+        ? convertedValue.toString()
+        : convertedValue.toFixed(currentDecimals);
+      $('#result').text(`${rawInput} ${from} = ${formattedConverted} ${to}`);
+    } else {
+      $('#result').text('Conversion rate not available.');
+    }
+  }).fail(function() {
+    $('#result').text('Error fetching conversion rate.');
+  });
+}
+
+function setCurrentDecimals(dec) {
+  currentDecimals = dec.toString();
+}
+
+if (typeof window !== 'undefined') {
+  window.convertCurrency = convertCurrency;
+  window.setCurrentDecimals = setCurrentDecimals;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { convertCurrency, setCurrentDecimals };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "currency-conversion",
+  "version": "1.0.0",
+  "description": "Currency converter project",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jquery": "^3.6.0"
+  }
+}

--- a/tests/convertCurrency.test.js
+++ b/tests/convertCurrency.test.js
@@ -1,0 +1,52 @@
+const $ = require('jquery');
+global.$ = $;
+const { convertCurrency, setCurrentDecimals } = require('../convertCurrency.js');
+
+describe('convertCurrency', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="amount" />
+      <select id="from-currency">
+        <option value="USD">USD</option>
+        <option value="EUR">EUR</option>
+      </select>
+      <select id="to-currency">
+        <option value="USD">USD</option>
+        <option value="EUR">EUR</option>
+      </select>
+      <div id="result"></div>
+    `;
+    setCurrentDecimals('2');
+    $.getJSON = jest.fn();
+  });
+
+  test('selecting the same currency echoes the input amount', () => {
+    $('#amount').val('100');
+    $('#from-currency').val('USD');
+    $('#to-currency').val('USD');
+
+    convertCurrency();
+
+    expect($('#result').text()).toBe('100 USD = 100 USD');
+    expect($.getJSON).not.toHaveBeenCalled();
+  });
+
+  test('different decimal settings produce correctly rounded output', () => {
+    $('#amount').val('1.005');
+    $('#from-currency').val('USD');
+    $('#to-currency').val('EUR');
+
+    $.getJSON.mockImplementation((url, success) => {
+      success({ rates: { EUR: 0.5 } });
+      return { fail: jest.fn() };
+    });
+
+    setCurrentDecimals('2');
+    convertCurrency();
+    expect($('#result').text()).toBe('1.005 USD = 0.50 EUR');
+
+    setCurrentDecimals('3');
+    convertCurrency();
+    expect($('#result').text()).toBe('1.005 USD = 0.503 EUR');
+  });
+});


### PR DESCRIPTION
## Summary
- expose currency conversion logic through `convertCurrency.js`
- wire HTML to new module and decimal setter
- add Jest tests covering same-currency and decimal rounding scenarios

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8adda9368832cacc902f6db7f2727